### PR TITLE
Force to string the attribute value in DBMS_CLOUD_AI.SET_ATTRIBUTE()

### DIFF
--- a/src/server/utils/selectai.py
+++ b/src/server/utils/selectai.py
@@ -60,6 +60,10 @@ def set_profile(
     logger.info("Updating SelectAI Profile (%s) attribute: %s = %s", profile_name, attribute_name, attribute_value)
     # Attribute Names: provider, credential_name, object_list, provider_endpoint, model
     # Attribute Names: temperature, max_tokens
+    
+    if isinstance(attribute_value, float) or isinstance(attribute_value, int):
+        attribute_value = str(attribute_value)
+
     binds = {"profile_name": profile_name, "attribute_name": attribute_name, "attribute_value": attribute_value}
     sql = """
             BEGIN


### PR DESCRIPTION
This solves issue #198 since to set_profile is passed a float/int value. string conversion avoid issue in DBMS_CLOUD_AI  execution